### PR TITLE
#168243621 view-mentors and #168243643 specific-mentor

### DIFF
--- a/server/controllers/mentors.js
+++ b/server/controllers/mentors.js
@@ -1,0 +1,31 @@
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import _ from 'lodash';
+import express from 'express';
+import response from '../helpers/response';
+import models from '../models';
+const router = express.Router();
+
+const listMentors = async (req, res) => {
+  const searchMentors = models.users.filter(sts => sts.role === 'mentor');
+  if (searchMentors) {
+    response.response(res, 200, 200, searchMentors);
+  }
+};
+
+const profileMentor = async (req, res) => {
+  const { id } = req.params;
+  const userId = models.users.find(
+    usr => usr.id == parseInt(id, 10) && usr.role == 'mentor'
+  );
+  if (userId) {
+    response.response(res, 200, 200, userId);
+  } else {
+    response.response(res, 404, 404, true);
+  }
+};
+
+export default {
+  listMentors,
+  profileMentor
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -12,7 +12,7 @@ const users = [
     phoneNumber: ' +250782314242',
     address: 'UMUSAVE',
     role: 'mentor',
-    isAdmin: false
+    isAdmin: true
   },
   {
     id: 2,

--- a/server/routes/mentors.js
+++ b/server/routes/mentors.js
@@ -1,10 +1,8 @@
 import { Router } from 'express';
+import mentors from '../controllers/mentors';
+
 const router = Router();
-router.get('/mentors', (req, res) => {
-  return res.send('Users can view mentors.');
-});
-router.get('/mentors/:mentorId', (req, res) => {
-  return res.send('Users can view a specific mentor.');
-});
+router.get('/mentors', mentors.listMentors);
+router.get('/mentors/:id', mentors.profileMentor);
 
 export default router;

--- a/server/test/mentors.spec.js
+++ b/server/test/mentors.spec.js
@@ -1,0 +1,43 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import mentors from '../controllers/mentors';
+import users from '../models';
+const should = chai.should();
+chai.use(chaiHttp);
+chai.should();
+
+describe('GET /', () => {
+  it('It should display all mentors ', done => {
+    chai
+      .request(app)
+      .get('/api/v1/mentors')
+      .send()
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('It should display a specific mentor ', done => {
+    chai
+      .request(app)
+      .get('/api/v1/mentors/1')
+      .send()
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('It should not return mentor if there is no mentor found with specific id', done => {
+    chai
+      .request(app)
+      .get('/api/v1/mentors/10')
+      .send()
+      .end((err, res) => {
+        expect(res.status).to.equal(404);
+        done();
+      });
+  });
+});

--- a/server/test/user.spec.js
+++ b/server/test/user.spec.js
@@ -239,7 +239,7 @@ describe('POST /', () => {
 // test Change User to mentor
 
 describe('PATCH /', () => {
-  it('It should cancel a user to mentor request if admin ', done => {
+  it('It should accept a user to mentor request if admin ', done => {
     const Signed = {
       id: 6,
       email: 'newuser@gmail.com',


### PR DESCRIPTION
## ## What does this PR do?
User Should view all mentors and should be able to view specific mentor

#### Description of Task to be completed?
- added listMentors controller function 
- added profileMentor controller function
- added mentors Route to navigate link
- adding test to check if it works

#### How should this be manually tested?
Clone the repository and cd into it. run npm install and after run npm start. Open postman and run
http://localhost/api/v1/mentors , http://localhost/api/v1/mentors/:id and the add required parameters in a body.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?

#168243621
#168243643
#### Screenshots (if appropriate)
![all mentors](https://user-images.githubusercontent.com/51251401/64332015-1989fa00-cfd4-11e9-8a67-596b38d184f1.png)
![specific mentor](https://user-images.githubusercontent.com/51251401/64332086-38888c00-cfd4-11e9-85eb-88050d8db528.png)


Questions: